### PR TITLE
Add Bambda for host header injection checks

### DIFF
--- a/CustomAction/CheckHostHeaderInjections.bambda
+++ b/CustomAction/CheckHostHeaderInjections.bambda
@@ -1,0 +1,26 @@
+id: d1f1a24f-2be4-49a0-b6e6-15c9fb030856
+name: Check host header injections
+function: CUSTOM_ACTION
+location: REPEATER
+source: |+
+  /**
+  * Check for host header injections
+  *
+  * @author GrumpinouT
+  **/
+
+  // Define request
+  var req = requestResponse.request();
+  
+  // Change host header
+  var collaborator = api().collaborator().defaultPayloadGenerator().generatePayload().toString();
+  api().http().sendRequest(req.withUpdatedHeader("Host", collaborator));
+  logging().logToOutput("Collaborator as host header - " + collaborator);
+  
+  // Append collaborator domain to host header
+  var collaborator1 = api().collaborator().defaultPayloadGenerator().generatePayload().toString();
+  api().http().sendRequest(req.withUpdatedHeader("Host", req.headerValue("Host") + "." + collaborator1));
+  logging().logToOutput("Append collaborator to host header - " + collaborator1);
+  
+  // Change port in host header to '1'
+  logging().logToOutput("Added port ':1' to Host header - " + api().http().sendRequest(req.withUpdatedHeader("Host", req.headerValue("Host").replace(":\\d+$", "") + ":1")).response().statusCode());


### PR DESCRIPTION
This bambda does some basic modifications on the host header, to check for possible injections

### Bambda Contributions

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [x] Bambda compiles and executes as expected
* [x] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
* [x] Bambda is in valid yaml format, and has a name, id, function, and location. To ensure this is correct, export the Bambda from your Bambda library in Burp.
